### PR TITLE
Fix some corrupted string and number output problems.

### DIFF
--- a/cpp/xml_format.cc
+++ b/cpp/xml_format.cc
@@ -1,5 +1,7 @@
 #include <sstream>
+#include <stdint.h>
 #include <iostream>
+#include <iomanip>
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/descriptor.pb.h>
 
@@ -20,7 +22,12 @@ namespace protobuf {
 
 
 XmlFormat::Printer::Printer() {}
-XmlFormat::Printer::~Printer() {}
+XmlFormat::Printer::~Printer() {
+	for (size_t i = 0; i < _string_pointers_.size(); ++i) {
+		delete _string_pointers_[i];
+	}
+	_string_pointers_.clear();
+}
 
 void XmlFormat::Printer::PrintToXmlString(const Message& message,
                                         string* output) {
@@ -92,7 +99,7 @@ void XmlFormat::Printer::PrintXmlField(const Message& message,
 }
 
 
-string XmlFormat::Printer::GetXmlFieldName(const Message& message,
+const string & XmlFormat::Printer::GetXmlFieldName(const Message& message,
                                          const Reflection* reflection,
                                          const FieldDescriptor* field) {
 	if (field->is_extension()) {
@@ -136,11 +143,13 @@ void XmlFormat::Printer::PrintXmlFieldValue(
           reflection->GetRepeated##METHOD(message, field, field_index) :     \
           reflection->Get##METHOD(message, field);                          \
         stringstream number_stream; \
-	    number_stream << value; \
+	    number_stream << setprecision(12) << value; \
+		string *pStr = new string(number_stream.str()); \
+		_string_pointers_.push_back(pStr); \
     	rapidxml::xml_node<> *string_node = doc->allocate_node(              \
     	  rapidxml::node_element,                                      \
     	  GetXmlFieldName(message, reflection, field).c_str(),         \
-    	  number_stream.str().c_str());                                              \
+    	  pStr->c_str());                                              \
     	node->append_node(string_node);                                      \
         break;                                                               \
       }

--- a/cpp/xml_format.h
+++ b/cpp/xml_format.h
@@ -7,6 +7,7 @@
 #define GOOGLE_PROTOBUF_XML_FORMAT_H__
 
 #include <string>
+#include <vector>
 #include "rapidxml-1.13/rapidxml.hpp"
 
 #include <google/protobuf/message.h>
@@ -56,7 +57,7 @@ class LIBPROTOBUF_EXPORT XmlFormat {
 
     // Utility function to return the right name function based
     // on field type
-    string GetXmlFieldName(const Message& message,
+    const string & GetXmlFieldName(const Message& message,
                         const Reflection* reflection,
                         const FieldDescriptor* field);
 
@@ -69,6 +70,10 @@ class LIBPROTOBUF_EXPORT XmlFormat {
                  		rapidxml::xml_document<>* doc,
              			rapidxml::xml_node<>* node);
 
+    // Hold new allocaated object pointers for later deleting at destructor function,
+    // because rapidxml only holds pointers of strings(const char *)
+    // that we have to make sure the pointers are valid while using them.
+    std::vector<std::string*> _string_pointers_;
   };
 
 

--- a/py/xml_format.py
+++ b/py/xml_format.py
@@ -71,7 +71,8 @@ def CreateXmlFieldValue(field, value, doc, element):
         element.appendChild(field_value)
     elif field.cpp_type == descriptor.FieldDescriptor.CPPTYPE_STRING:
         # should this be escaped?
-        field_value = doc.createTextNode(str(_CEscape(value)))
+#        field_value = doc.createTextNode(str(_CEscape(value)))
+        field_value = doc.createTextNode(value)
         element.appendChild(field_value)
         pass
     elif field.cpp_type == descriptor.FieldDescriptor.CPPTYPE_BOOL:


### PR DESCRIPTION
Recently I am trying to transfer pb message to xml file for easier debugging. Fortunately I found your pb2xml project, it help me a lot. Thank you! 

While testing on my pb data, I found some bugs about string and number output in cpp version. And for debugging purpose I want to see unescaped utf-8 string in XML file. So I forked the code and make some change.

- Fix python version's string value problem.
In fact it is not a real problem, I just want to see **unescaped** utf-8 string in XML file.

- Fix cpp version's corrupted string and number output problems.
As mentioned in [PrintToXmlString produces corrupted string output](https://github.com/tmarthal/pb2xml/issues/2), rapidxml only hold pointers of string object(const char *), so we have to make sure the pointers are valid while rapidxml using them.
I found two place needed to be fixed.
The first one is the xml node name which use string returned from GetXmlFieldName function, since the returned string object is local variable that we can NOT depend on it. By changing the return value type of GetXmlFieldName from "string" to "const string &", we fix it.
The second one is OUTPUT_FIELD macro which use string returned from stringstream's str() function, it is also a temporary variable. By adding member variable of Printer for holding new allocated string object, we fix it.

In my test it works well. Hope it help.

Best regard!