### PR TITLE
Fix for latest protobuf API

### DIFF
--- a/py/xml_format.py
+++ b/py/xml_format.py
@@ -4,7 +4,7 @@
 from xml.dom.minidom import Document
 
 from google.protobuf import descriptor
-from google.protobuf.text_format import _CEscape
+from google.protobuf.text_encoding import CEscape
 
 __all__ = [ 'MessageToXML', 'MessageToDOM', 
             'CreateXmlMessage', 'CreateXmlField', 'CreateXmlFieldValue', 
@@ -71,7 +71,7 @@ def CreateXmlFieldValue(field, value, doc, element):
         element.appendChild(field_value)
     elif field.cpp_type == descriptor.FieldDescriptor.CPPTYPE_STRING:
         # should this be escaped?
-        field_value = doc.createTextNode(str(_CEscape(value)))
+        field_value = doc.createTextNode(str(CEscape(value, True)))
         element.appendChild(field_value)
         pass
     elif field.cpp_type == descriptor.FieldDescriptor.CPPTYPE_BOOL:


### PR DESCRIPTION
The current ``protobuf`` package has changed where the ``CEscape`` function is located. This merge request fixes the imports and call so that the XML conversion works again when using a current google protobuf library.